### PR TITLE
Fix split stack causing black screen in list view

### DIFF
--- a/lib/widgets/token_card.dart
+++ b/lib/widgets/token_card.dart
@@ -300,9 +300,7 @@ class TokenCard extends StatelessWidget {
                   backgroundColor: Colors.transparent,
                   builder: (context) => SplitStackSheet(
                     item: item,
-                    onSplitCompleted: () {
-                      Navigator.of(context).pop();
-                    },
+                    // No onSplitCompleted callback - sheet dismisses itself
                   ),
                 );
               } : null,


### PR DESCRIPTION
The split stack button from TokenCard was providing an onSplitCompleted callback that called Navigator.pop(), which was closing the entire list view instead of just the split sheet. Removed the unnecessary callback since the split sheet already dismisses itself. The callback is still used in ExpandedTokenScreen where it's needed to return to the main list.