### PR TITLE
fix floating action menu overflow on iOS simulators

### DIFF
--- a/lib/widgets/floating_action_menu.dart
+++ b/lib/widgets/floating_action_menu.dart
@@ -67,8 +67,9 @@ class _ActionBottomSheet extends StatelessWidget {
         color: Theme.of(context).scaffoldBackgroundColor,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
       ),
-      padding: const EdgeInsets.all(24),
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
       child: SafeArea(
+        minimum: const EdgeInsets.only(bottom: 24),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: doubling_season
 description: A Flutter app for tracking Magic The Gathering tokens during gameplay.
 publish_to: 'none'
-version: 1.0.3+3
+version: 1.0.3+5
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Adjusted bottom padding in FloatingActionMenu to prevent 10px overflow on iOS devices with home indicators. Changed Container padding to exclude bottom and added SafeArea minimum padding to properly handle safe area insets.
